### PR TITLE
add eventStack priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ activateKeyboard: on('didInsertElement', function() {
 })
 ```
 
-This will place the component at the bottom of the `eventStack`, meaning that it will be the first component to respond to a key event. Let's say you want your component to respond to the key `a` as well as `ctrl+shift+a`:
+This will place the component in the `eventStack`, meaning it'll be able to respond to key events. Let's say you want your component to respond to the key `a` as well as `ctrl+shift+a`. You could do so with:
 
 ```js
 aFunction: on('keyUp:a', function() {
@@ -40,7 +40,7 @@ anotherFunction: on('keyUp:ctrl+shift+a', function() {
 })
 ```
 
-The modifier keys include `ctrl`, `shift`, `alt`, and `meta`. For a full list of the primary keys (such as `a`, `1`, ` `, `Escape`, and `ArrowLeft`), look [here](https://github.com/Ticketfly/ember-keyboard/addon/fixtures/key-map.js).
+The modifier keys include `ctrl`, `shift`, `alt`, and `meta`. For a full list of the primary keys (such as `a`, `1`, ` `, `Escape`, and `ArrowLeft`), look [here](https://github.com/Ticketfly/ember-keyboard/blob/master/addon/fixtures/key-map.js).
 
 Finally, when you're ready for a component to leave the `eventStack` you can deactivate it:
 
@@ -50,15 +50,39 @@ deactivateKeyboard: on('willDestroyElement', function() {
 })
 ```
 
+## Responder Properties
+
+`ember-keyboard` will search the components in its `eventStack` for optional properties. These options provide greater control over `ember-keyboard`'s event bubbling.
+
+### `keyboardPriority`
+
+By default, all activated components are treated as equal. If you have two components that respond to `ctrl+a`, then both will get triggered when there's a `ctrl+a` event. However, this behavior is undesirable in some scenarios. What if you have a modal open, and you only want it and its child components to respond to key events. You can get this behavior by assigning a priority to the modal and its children:
+
+```js
+noPriorityComponent; // priority defaults to 0
+lowPriorityComponent.set('keyboardPriority', 0);
+
+modal.set('keyboardPriority', 1);
+modalChild.set('keyboardPriority', 1);
+```
+
+In this scenario, when a key is pressed both `modal` and `modalChild` will have a chance to respond to it, while the remaining components will not. Once `modal` and `modalChild` are deactivated or their priority is removed, then `lowPriorityComponent` and `noPriorityComponent` will respond to key events.
+
+Note that priority is descending, so higher numbers have precedence.
+
+### `keyboardFirstResponder`
+
+Sometimes you'll want a component to temporarily become the first responder, regardless of its priority. For instance, a user might click or focusIn an unprioritized item. When that happens, you can temporarily give it first responder priority by:
+
+```js
+keyboard.activate(component);
+
+component.set('keyboardFirstPriority', true);
+```
+
+You can later `component.set('keyboardFirstResponder', false)` and the component will automatically return to its original priority. Additionally, if you set another component to `keyboardFirstResponder`, the previous `keyboardFirstResponder` will return to its old priority.
+
 ## Concepts & Advanced Usage
-
-### Event Bubbling
-
-When you run `this.get('keyboard').activate(this)`, you place a component at the bottom of the `eventStack`. When a key is pressed, it will be first to respond. If it lacks a registered listener for that key, then it will bubble the event up to the next component on the stack. This will continue until the event is handled or it terminates at the top of the stack. This allows you to have mutliple component responders, with precedence given to components lower on the stack.
-
-As an example, imagine that you have a `search-bar` component that you want to focus whenever the user presses the `s` key. At the same time, you have a `nav-bar` component that responds to `ArrowLeft` and `ArrowRight`. When the `s` key is pressed, it first passes through `nav-bar` at the bottom of the stack. Since there are no `keyUp:s` listeners, the event bubbles up to `search-bar`, which can than respond to the keypress.
-
-Now let's say your `modal-dialog` component pops up. It also responds to `ArrowLeft` and `ArrowRight` to cycle through modal states. When the user clicks `ArrowRight`, the event now goes to `modal-dialog` which has arrived at the bottom of the stack. Since it has a listener for `ArrowRight`, it handles the keypress and the event never bubbles up to `nav-bar`.
 
 ### `keyUp` and `keyDown`
 

--- a/addon/initializers/ember-keyboard-reopen-component.js
+++ b/addon/initializers/ember-keyboard-reopen-component.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export function initialize() {
+  Ember.Component.reopen({
+    keyboardPriority: 0
+  });
+}
+
+export default {
+  name: 'ember-keyboard-reopen-component',
+  initialize: initialize
+};

--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -8,18 +8,47 @@ const {
 } = Ember;
 
 export default Service.extend({
-  responderStack: computed(() => Ember.A()),
+  _responderStack: computed(() => Ember.A()),
 
   activate(responder) {
-    const responderStack = this.get('responderStack');
-
     // ensure the responder appears only once in the stack
-    responderStack.removeObject(responder);
-    responderStack.unshiftObject(responder);
+    this.deactivate(responder);
+    this.get('_responderStack').pushObject(responder);
   },
 
   deactivate(responder) {
-    this.get('responderStack').removeObject(responder);
+    this.get('_responderStack').removeObject(responder);
+  },
+
+  sortedResponderStack: computed('_responderStack.@each.keyboardPriority',
+                                 '_responderStack.@each.keyboardFirstResponder', {
+    get() {
+      this._ensureSingleFirstResponder();
+
+      return this.get('_responderStack').sort((a, b) => {
+        // place the keyboardFirstResponder at the top of the stack
+        if (a.keyboardFirstResponder) {
+          return -1;
+        } else if (b.keyboardFirstResponder) {
+          return 1;
+        }
+
+        // otherwise, sort by priority
+        return b.keyboardPriority - a.keyboardPriority;
+      });
+    }
+  }).readOnly(),
+
+  _ensureSingleFirstResponder() {
+    const responderStack = this.get('_responderStack');
+    const firstResponders = responderStack.filterBy('keyboardFirstResponder');
+
+    firstResponders.forEach((responder, index) => {
+      // the last responder will always be the new keyboardFirstResponder
+      if (index === firstResponders.length - 1) { return; }
+
+      responder.set('keyboardFirstResponder', undefined);
+    });
   },
 
   _initializeListener: on('init', function() {
@@ -28,7 +57,7 @@ export default Service.extend({
     }).join(' ');
 
     Ember.$(document).on(eventNames, null, (event) => {
-      handleKeyEvent(event, this.get('responderStack'));
+      handleKeyEvent(event, this.get('sortedResponderStack'));
     });    
   }),
 

--- a/addon/utils/handle-key-event.js
+++ b/addon/utils/handle-key-event.js
@@ -37,16 +37,30 @@ const gatherKeys = function gatherKeys(event) {
 };
 
 export default function handleKeyEvent(event, responderStack) {
-  let triggeredVariant;
   const keys = gatherKeys(event);
   const variants = gatherEventNameVariants(event, keys);
 
-  // Finds the first responder with a registered listener for one of the variants
-  const responder = responderStack.find((responder) => {
-    return triggeredVariant = variants.find((variant) => hasListeners(responder, variant));
-  });
+  // bug note: would prefer to use `responderStack.get('firstObject')` here, but it's returning the
+  // firstObject prior to sorting
+  const priority = responderStack[0].get('keyboardPriority');
 
-  if (responder) {
-    responder.trigger(triggeredVariant);
-  }
+  // trigger the event on all responders in the priority level
+  const responder = responderStack.find((responder) => {
+    // responders are sorted by priority (ascending). short-circuit `find` once the responders
+    // exceed the initial responder's priority
+    if (responder.get('keyboardPriority') !== priority) {
+      return true;
+    }
+
+    const triggeredVariant = variants.find((variant) => hasListeners(responder, variant));
+
+    if (triggeredVariant) {
+      responder.trigger(triggeredVariant);
+    }
+
+    // short-circuit `find` if `keyboardFirstResponder`, but only after triggering the event
+    if (responder.get('keyboardFirstResponder')) {
+      return true;
+    }
+  });
 }

--- a/app/initializers/ember-keyboard-reopen-component.js
+++ b/app/initializers/ember-keyboard-reopen-component.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-keyboard/initializers/ember-keyboard-reopen-component';

--- a/tests/acceptance/ember-keyboard-test.js
+++ b/tests/acceptance/ember-keyboard-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 
+const search = '.input';
 const modal = '.modal';
 const modalCounter = '.modal-counter';
 const standAloneCounter = '.standalone-counter';
@@ -33,5 +34,10 @@ test('run the paces', function(assert) {
   }).then(() => {
     assert.equal(Ember.$(modalCounter).text().trim(), '1', 'modal counter respond to keydown event');
     assert.equal(Ember.$(standAloneCounter).text().trim(), '-1', 'standalone counter is blocked by modal counter');
+
+    // press 's'
+    return keyEvent(document, 'keyup', 83);
+  }).then(() => {
+    assert.ok(!Ember.$(search).is(':focus'), 'event does not bubble after modal');
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -12,8 +12,8 @@
 
   {{search-bar}}
 
-  {{#modal-container}}
-    {{counter-box classNames='modal-counter'}}
+  {{#modal-container modalKeyboardPriority=1}}
+    {{counter-box classNames='modal-counter' keyboardPriority=1}}
   {{/modal-container}}
 
   {{counter-box classNames='standalone-counter'}}

--- a/tests/dummy/app/templates/components/modal-container.hbs
+++ b/tests/dummy/app/templates/components/modal-container.hbs
@@ -1,5 +1,5 @@
 {{#if isOpen}}
-  {{#modal-container/modal closeModal=(action 'closeModal')}}
+  {{#modal-container/modal keyboardPriority=modalKeyboardPriority closeModal=(action 'closeModal')}}
     {{yield}}
   {{/modal-container/modal}}
 {{/if}}

--- a/tests/unit/initializers/ember-keyboard-reopen-component-test.js
+++ b/tests/unit/initializers/ember-keyboard-reopen-component-test.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import { initialize } from '../../../initializers/ember-keyboard-reopen-component';
+import { module, test } from 'qunit';
+
+var registry, application;
+
+module('Unit | Initializer | ember keyboard reopen component', {
+  beforeEach: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      registry = application.registry;
+      application.deferReadiness();
+    });
+  }
+});
+
+test('Ember.Component is reopened', function(assert) {
+  initialize();
+
+  assert.equal(Ember.Component.create().get('keyboardPriority'), 0, 'keyboardPriority defaults to 0');
+});

--- a/tests/unit/services/keyboard-test.js
+++ b/tests/unit/services/keyboard-test.js
@@ -1,27 +1,72 @@
+import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('service:keyboard', 'Unit | Service | keyboard');
 
-test('`activate` adds the supplied responder to the responderStack', function(assert) {
+// transforms Ember.Objects and Ember.Arrays into normal objects and arrays
+const normalize = function normalize(data) {
+  return JSON.parse(JSON.stringify(data));
+};
+
+test('`activate` adds the supplied responder to the _responderStack', function(assert) {
   const service = this.subject();
-  const responder = 'foo';
-  const secondResponder = 'bar';
+  const responder = Ember.Object.create({ name: 'foo' });
+  const secondResponder = Ember.Object.create({ name: 'bar' });
 
   service.activate(responder);
-  assert.deepEqual(service.get('responderStack'), [responder], 'adds responder to responderStack');
+  assert.deepEqual(normalize(service.get('sortedResponderStack')), normalize([responder]), 'adds responder to sortedResponderStack');
 
   service.activate(responder);
-  assert.deepEqual(service.get('responderStack'), [responder], 'ensures responder uniquness');
+  assert.deepEqual(normalize(service.get('sortedResponderStack')), normalize([responder]), 'ensures responder uniquness');
 
   service.activate(secondResponder);
-  assert.deepEqual(service.get('responderStack'), [secondResponder, responder], 'adds to the top of the stack');
+  assert.deepEqual(normalize(service.get('sortedResponderStack')), normalize([responder, secondResponder]), 'adds to the top of the stack');
 });
 
-test('`deactivate` removes the supplied responder from the responderStack', function(assert) {
+test('`sortedResponderStack` sorts the sortedResponderStack by priorty', function(assert) {
   const service = this.subject();
-  const responder = 'foo';
+  const responder = Ember.Object.create({ name: 'foo', keyboardPriority: 2 });
+  const secondResponder = Ember.Object.create({ name: 'bar', keyboardPriority: 1 });
+  const thirdResponder = Ember.Object.create({ name: 'baz' });
+  const fourthResponder = Ember.Object.create({ name: 'beetle' });
+  const fifthResponder = Ember.Object.create({ name: 'EMT', keyboardFirstResponder: true });
+
+  service.activate(responder);
+  service.activate(secondResponder);
+  service.activate(thirdResponder);
+  service.activate(fourthResponder);
+  service.activate(fifthResponder);
+  
+  const expected = normalize([fifthResponder, responder, secondResponder, thirdResponder, fourthResponder]);
+
+  assert.deepEqual(normalize(service.get('sortedResponderStack')), expected, 'sort by priority ascending, non-priority at the end');
+});
+
+test('`_ensureSingleFirstResponder` ensures that only a single responder is firstResponder', function(assert) {
+  const service = this.subject();
+  const responder = Ember.Object.create({ name: 'foo', keyboardPriority: 3 });
+  const secondResponder = Ember.Object.create({ name: 'bar', keyboardPriority: 1 });
+  const thirdResponder = Ember.Object.create({ name: 'baz', keyboardPriority: 2 });
+  const fourthResponder = Ember.Object.create({ name: 'beetle' });
+
+  service.activate(responder);
+  service.activate(secondResponder);
+  service.activate(thirdResponder);
+  service.activate(fourthResponder);
+  
+  thirdResponder.set('keyboardFirstResponder', true);
+  fourthResponder.set('keyboardFirstResponder', true);
+  
+  const expected = ['beetle', 'foo', 'baz', 'bar'];
+
+  assert.deepEqual(service.get('sortedResponderStack').mapBy('name'), expected, 'ensures a single firstResponder');
+});
+
+test('`deactivate` removes the supplied responder from the _responderStack', function(assert) {
+  const service = this.subject();
+  const responder = Ember.Object.create({ name: 'bar' });
 
   service.activate(responder);
   service.deactivate(responder);
-  assert.deepEqual(service.get('responderStack'), [], 'removes responder from responderStack');
+  assert.deepEqual(normalize(service.get('sortedResponderStack')), [], 'removes responder from sortedResponderStack');
 });


### PR DESCRIPTION
@Ticketfly/frontenders 

This PR gives devs the ability to assign priority to components in the eventStack. For instance, they might set the `nav-bar` to respond to key events before the `search-bar`, regardless of when these components were activated.
